### PR TITLE
feat: docker Image 못읽어오는 현상 수정

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,7 +1,7 @@
 {
   "AWSEBDockerrunVersion": "1",
   "Image": {
-    "Name": "taglog",
+    "Name": "leejoonhyuk/taglog",
     "Update": "true"
   },
   "Environment": {


### PR DESCRIPTION
## issue & branch

- docker 빈화면이 보이는 error 
- aws nodata 오류 수정
  -  Environment health has transitioned from Pending to No Data. None of the instances are sending data.


## 작업 내용 (Content)

- Dockerrun.aws.json image 이름 잘못 되어 있는 것 수정
