### PR TITLE
feat: 에러 처리 로직 추가

### DIFF
--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -19,6 +19,7 @@ import Tag from '@/components/Tag';
 import { onCustomImageUpload } from '@/utils/frontend/image';
 import useEditor from '@/hooks/useEditor';
 
+import useAuthStore from '@/store/zustand/useAuthStore';
 import styles from './editor.module.scss';
 
 const mdParser = new MarkdownIt(/* Markdown-it options */);
@@ -45,6 +46,8 @@ export default function Editor() {
   const [tags, setTags] = useState<string[]>([]);
 
   const router = useRouter();
+
+  const setUserInfoInit = useAuthStore((state) => state.setUserInfoInit);
 
   const onAddTag = () => {
     const tagText = watch('tagText');
@@ -88,8 +91,10 @@ export default function Editor() {
         toast.error('server error');
         return;
       }
-      if (error.response.status >= 400 && error.response.status < 500) {
-        toast.error('client error');
+      if (error.response.status === 401) {
+        toast.error('Unauthorized : 로그인을 다시 해주세요');
+        setUserInfoInit();
+        router.push('/');
         return;
       }
       toast.error(error.message);

--- a/src/utils/frontend/axios.ts
+++ b/src/utils/frontend/axios.ts
@@ -17,13 +17,13 @@ authInstance.interceptors.request.use((config) => {
   const { accessToken } = authStore ? JSON.parse(authStore).state : '';
   if (!accessToken) {
     if (typeof window !== 'undefined') {
-      toast.error('토큰이 없습니다.');
+      toast.error('Unauthorized : 로그인을 다시 해주세요');
       setTimeout(() => {
         window.location.href = '/';
       }, 1000);
     }
 
-    return Promise.reject(new Error('토큰이 없습니다.'));
+    return Promise.reject(new Error('Unauthorized : 로그인을 다시 해주세요'));
   }
   const newConfig = { ...config };
   if (accessToken) {


### PR DESCRIPTION
#117 

## pr type

- [x] Feature


## 작업 내용 (Content)
- refreshToken 만료시 http status code 401로 넘어온 에러 처리 로직 추가.
  - zustand store 데이터 초기화로 client 측 로그아웃 처리
